### PR TITLE
Hotkeys - 'c' for opening card modals

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
         <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-        <sitemap><loc>https://circles.spect.network/sitemap-0.xml</loc></sitemap>
+        <sitemap><loc>https://yourdomain.com/sitemap-0.xml</loc></sitemap>
         </sitemapindex>


### PR DESCRIPTION
Pressing 'c' on the  keyboard opens up the first column card modal on the board.